### PR TITLE
Fix errors and warnings build swift/clangImporter using MSVC on Windows

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -563,6 +563,9 @@ OptionalTypeKind importer::translateNullability(clang::NullabilityKind kind) {
   case clang::NullabilityKind::Unspecified:
     return OptionalTypeKind::OTK_ImplicitlyUnwrappedOptional;
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 bool importer::hasDesignatedInitializers(
@@ -618,8 +621,12 @@ static bool isAccessibilityConformingContext(const clang::DeclContext *ctx) {
 
 bool
 importer::shouldImportPropertyAsAccessors(const clang::ObjCPropertyDecl *prop) {
+  // TODO (hughbe/MSVC): fix an error using SwiftImportPropertyAsAccessorsAttr
+  // Fails with: "SwiftImportPropertyAsAccessorsAttr" is not a member of 'clang'
+#if !defined(_MSC_VER)
   if (prop->hasAttr<clang::SwiftImportPropertyAsAccessorsAttr>())
     return true;
+#endif
 
   // Check if the property is one of the specially handled accessibility APIs.
   //

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -68,7 +68,9 @@ using namespace importer;
 using clang::CompilerInstance;
 using clang::CompilerInvocation;
 
+#if !defined(_MSC_VER)
 #pragma mark Internal data structures
+#endif
 
 namespace {
   class HeaderImportCallbacks : public clang::PPCallbacks {
@@ -280,7 +282,9 @@ void ClangImporter::clearTypeResolver() {
   Impl.setTypeResolver(nullptr);
 }
 
+#if !defined(_MSC_VER)
 #pragma mark Module loading
+#endif
 
 #ifdef NDEBUG
 #define SHIMS_INCLUDE_FLAG "-isystem"
@@ -1393,7 +1397,9 @@ ClangModuleUnit *ClangImporter::Implementation::getClangModuleForDecl(
   return getWrapperForModule(importer, M);
 }
 
+#if !defined(_MSC_VER)
 #pragma mark Source locations
+#endif
 clang::SourceLocation
 ClangImporter::Implementation::exportSourceLoc(SourceLoc loc) {
   // FIXME: Implement!
@@ -1412,7 +1418,9 @@ ClangImporter::Implementation::importSourceRange(clang::SourceRange loc) {
   return SourceRange();
 }
 
+#if !defined(_MSC_VER)
 #pragma mark Importing names
+#endif
 
 clang::DeclarationName
 ClangImporter::Implementation::exportName(Identifier name) {
@@ -1610,7 +1618,9 @@ bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
   return false;
 }
 
+#if !defined(_MSC_VER)
 #pragma mark Name lookup
+#endif
 const clang::TypedefNameDecl *
 ClangImporter::Implementation::lookupTypedef(clang::DeclarationName name) {
   clang::Sema &sema = Instance->getSema();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2739,6 +2739,9 @@ namespace {
         return nullptr;
       }
       }
+
+      // Work around MSVC warning: not all control paths return a value
+      llvm_unreachable("All switch cases are covered");
     }
 
 

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -222,6 +222,9 @@ void EnumInfo::determineConstantNamePrefix(ASTContext &ctx,
     case clang::AR_Unavailable:
       return false;
     }
+
+    // Work around MSVC warning: not all control paths return a value
+    llvm_unreachable("All switch cases are covered");
   };
 
   // Move to the first non-deprecated enumerator, or non-swift_name'd

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1094,7 +1094,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   // Objective-C categories and extensions don't have names, despite
   // being "named" declarations.
   if (isa<clang::ObjCCategoryDecl>(D))
-    return {};
+    return ImportedName();
 
   // Dig out the definition, if there is one.
   if (auto def = getDefinitionForClangTypeDecl(D)) {
@@ -1106,7 +1106,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   auto dc = const_cast<clang::DeclContext *>(D->getDeclContext());
   auto effectiveCtx = determineEffectiveContext(D, dc, options);
   if (!effectiveCtx)
-    return {};
+    return ImportedName();
   result.EffectiveContext = effectiveCtx;
 
   // FIXME: ugly to check here, instead perform unified check up front in
@@ -1192,7 +1192,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         if (!shouldImportAsInitializer(method, initPrefixLength,
                                        result.InitKind)) {
           // We cannot import this as an initializer anyway.
-          return {};
+          return ImportedName();
         }
 
         // If this swift_name attribute maps a factory method to an

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -130,6 +130,9 @@ struct ImportedName {
     case ImportedAccessorKind::SubscriptSetter:
       return true;
     }
+
+    // Work around MSVC warning: not all control paths return a value
+    llvm_unreachable("All switch cases are covered");
   }
 };
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -140,6 +140,9 @@ namespace {
     case ImportHint::SwiftNewtypeFromCFPointer:
       return true;
     }
+
+    // Work around MSVC warning: not all control paths return a value
+    llvm_unreachable("All switch cases are covered");
   }
 
   struct ImportResult {
@@ -173,6 +176,9 @@ namespace {
         return OptionalType::get(payloadType);
       return ImplicitlyUnwrappedOptionalType::get(payloadType);
     }
+
+    // Work around MSVC warning: not all control paths return a value
+    llvm_unreachable("All switch cases are covered");
   }
 
   class SwiftTypeConverter :
@@ -296,6 +302,9 @@ namespace {
       case clang::BuiltinType::OMPArraySection:
         return Type();
       }
+
+      // Work around MSVC warning: not all control paths return a value
+      llvm_unreachable("All switch cases are covered");
     }
 
     ImportResult VisitComplexType(const clang::ComplexType *type) {
@@ -783,6 +792,9 @@ namespace {
         return getAdjustedTypeDeclReferenceType(decl);
       }
       }
+
+      // Work around MSVC warning: not all control paths return a value
+      llvm_unreachable("All switch cases are covered");
     }
 
     ImportResult VisitObjCObjectType(const clang::ObjCObjectType *type) {
@@ -1051,6 +1063,9 @@ static bool canBridgeTypes(ImportTypeKind importKind) {
   case ImportTypeKind::BridgedValue:
     return true;
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 /// True if the type has known CoreFoundation reference counting semantics.
@@ -1075,6 +1090,9 @@ static bool isCFAudited(ImportTypeKind importKind) {
   case ImportTypeKind::PropertyWithReferenceSemantics:
     return true;
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 /// Turn T into Unmanaged<T>.
@@ -1744,6 +1762,9 @@ adjustResultTypeForThrowingFunction(const ImportedErrorInfo &errorInfo,
   case ForeignErrorConvention::NonNilError:
     return resultTy;
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
                                      
 /// Produce the foreign error convention from the imported error info,

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -214,6 +214,9 @@ bool SwiftLookupTable::contextRequiresName(ContextKind kind) {
   case ContextKind::TranslationUnit:
     return false;
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 /// Try to translate the given Clang declaration into a context.
@@ -293,6 +296,9 @@ SwiftLookupTable::translateContext(EffectiveClangContext context) {
 
     return None;
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 /// Lookup an unresolved context name and resolve it to a Clang


### PR DESCRIPTION
Strange TODO here due to missing SwiftImportPropertyAsAccessorsAttr